### PR TITLE
Do not wire up sample applications endpoints when IsDebuggingEnabled is false

### DIFF
--- a/samples/UsageSample/Startup.cs
+++ b/samples/UsageSample/Startup.cs
@@ -19,7 +19,10 @@ namespace RimDev.Stuntman.UsageSample
                     .AddClaim("given_name", "Sam")
                     .AddClaim("family_name", "Smith"));
 
-            app.UseStuntman(options);
+            if (System.Web.HttpContext.Current.IsDebuggingEnabled)
+            {
+                app.UseStuntman(options);
+            }
 
             var userPicker = new UserPicker(options);
 
@@ -39,8 +42,13 @@ namespace RimDev.Stuntman.UsageSample
                         "Hello, {0}. This is the /secure endpoint.",
                         userName));
 
-                    return context.Response.WriteAsync(
-                        userPicker.GetHtml(context.Request.User, context.Request.Uri.AbsoluteUri));
+                    if (System.Web.HttpContext.Current.IsDebuggingEnabled)
+                    {
+                        context.Response.WriteAsync(
+                            userPicker.GetHtml(context.Request.User, context.Request.Uri.AbsoluteUri));
+                    }
+
+                    return Task.FromResult(true);
                 });
             });
 
@@ -67,8 +75,13 @@ namespace RimDev.Stuntman.UsageSample
                         "Hello, {0}.",
                         userName));
 
-                    return context.Response.WriteAsync(
-                        userPicker.GetHtml(context.Request.User, context.Request.Uri.AbsoluteUri));
+                    if (System.Web.HttpContext.Current.IsDebuggingEnabled)
+                    {
+                        context.Response.WriteAsync(
+                            userPicker.GetHtml(context.Request.User, context.Request.Uri.AbsoluteUri));
+                    }
+
+                    return Task.FromResult(true);
                 });
             });
         }

--- a/samples/UsageSampleMvc/Startup.cs
+++ b/samples/UsageSampleMvc/Startup.cs
@@ -12,7 +12,10 @@ namespace RimDev.Stuntman.UsageSampleMvc
                     .AddClaim("given_name", "John")
                     .AddClaim("family_name", "Doe"));
 
-            app.UseStuntman(options);
+            if (System.Web.HttpContext.Current.IsDebuggingEnabled)
+            {
+                app.UseStuntman(options);
+            }
         }
     }
 }


### PR DESCRIPTION
#23.

Thoughts on the **System.Web** dependency? Is there a better way? **Debugger.IsAttached** comes to mind, but i'm not sold on that either. We could also check if the DEBUG constant exists.

I'm leaning toward checking if the DEBUG constant exists, but I'll leave this PR wired to **System.Web.HttpContext.Current.IsDebuggingEnabled** until we reach a decision.
