### PR TITLE
Run grunt automatically after Core build

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\build\Build.Settings.targets" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -80,4 +80,10 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PreBuildEvent>npm install -g grunt-cli</PreBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PostBuildEvent>grunt</PostBuildEvent>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
This implies everything on the developer machine is setup and ready to go. Perhaps we should wait until the necessary prerequisites to the README.md have been merged (see #9) before merging this?
