### PR TITLE
Fix package dependencies

### DIFF
--- a/build/Build.Version.targets
+++ b/build/Build.Version.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
     <MinorVersion>2</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/build/Build.msbuild
+++ b/build/Build.msbuild
@@ -50,11 +50,11 @@
 
   <Target Name="Package" DependsOnTargets="Clean; Build; Test">
     <ItemGroup>
-      <NuGetSpecs Include="$(RootPath)**\*.nuspec" />
+      <NuGetSpecs Include="$(RootPath)src\**\*.csproj" />
     </ItemGroup>
 
     <MakeDir Directories="$(ArtifactsPath)" Condition=" !Exists('$(ArtifactsPath)') " />
 
-    <Exec Command="$(NuGetPath) pack %(NuGetSpecs.Identity) -outputdirectory $(ArtifactsPath) -version $(PackageVersion)" />
+    <Exec Command="$(NuGetPath) pack %(NuGetSpecs.Identity) -p Configuration=$(Configuration) -outputdirectory $(ArtifactsPath) -version $(PackageVersion)" />
   </Target>
 </Project>

--- a/src/Core/Core.nuspec
+++ b/src/Core/Core.nuspec
@@ -11,8 +11,4 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <tags>rimdev stuntman aspnet identity impersonation</tags>
   </metadata>
-  <files>
-    <file src="bin\Release\RimDev.Stuntman.Core.dll" target="lib\net45" />
-    <file src="bin\Release\RimDev.Stuntman.Core.pdb" target="lib\net45" />
-  </files>
 </package>

--- a/src/Core/packages.config
+++ b/src/Core/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Grunt" version="0.1.13" targetFramework="net45" />
+  <package id="Grunt" version="0.1.13" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Security" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Security.Cookies" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Security.OAuth" version="3.0.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
-  <package id="Node.js" version="0.10.26.1" targetFramework="net45" />
-  <package id="NoGit" version="0.0.5" targetFramework="net45" />
-  <package id="Npm" version="1.4.4" targetFramework="net45" />
+  <package id="Node.js" version="0.10.26.1" targetFramework="net45" developmentDependency="true" />
+  <package id="NoGit" version="0.0.5" targetFramework="net45" developmentDependency="true" />
+  <package id="Npm" version="1.4.4" targetFramework="net45" developmentDependency="true" />
   <package id="Owin" version="1.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The build script should run `nuget pack` against the project file instead of the Nuspec so that NuGet dependencies are automatically generated for the package.

Fixes #32.
