### PR TITLE
Restrict stuntman from 'normal' production builds by default

### DIFF
--- a/src/Core/IAppBuilderExtensions.cs
+++ b/src/Core/IAppBuilderExtensions.cs
@@ -19,6 +19,8 @@ namespace RimDev.Stuntman.Core
 
         public static void UseStuntman(this IAppBuilder app, StuntmanOptions options)
         {
+            options.VerifyUsageIsPermitted();
+
             app.UseOAuthBearerAuthentication(new OAuthBearerAuthenticationOptions()
             {
                 AuthenticationType = StuntmanAuthenticationType,

--- a/src/Core/UserPicker.cs
+++ b/src/Core/UserPicker.cs
@@ -19,6 +19,8 @@ namespace RimDev.Stuntman.Core
             if (currentPrincipal == null) throw new ArgumentNullException("currentPrincipal");
             if (returnUrl == null) throw new ArgumentNullException("returnUrl");
 
+            _options.VerifyUsageIsPermitted();
+
             var css = Resources.GetCss();
 
             var currentUser = currentPrincipal.Identity.Name;

--- a/tests/Core.Tests/Core.Tests.csproj
+++ b/tests/Core.Tests/Core.Tests.csproj
@@ -88,6 +88,7 @@
     <Compile Include="..\..\common\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
+    <Compile Include="StuntmanOptionsFactory.cs" />
     <Compile Include="StuntmanOptionsTests.cs" />
     <Compile Include="StuntmanUsersTests.cs" />
     <Compile Include="UserPickerTests.cs" />

--- a/tests/Core.Tests/IAppBuilderExtensionsTests.cs
+++ b/tests/Core.Tests/IAppBuilderExtensionsTests.cs
@@ -16,7 +16,7 @@ namespace RimDev.Stuntman.Core.Tests
             [Fact]
             public async Task SignInUri_Returns200Ok()
             {
-                var options = new StuntmanOptions();
+                var options = StuntmanOptionsFactory.GetDefaultTestOptions();
 
                 using (var server = TestServer.Create(app =>
                 {
@@ -31,7 +31,7 @@ namespace RimDev.Stuntman.Core.Tests
             [Fact]
             public async Task SignInUri_IfOverrideNotSpecified_ShowsLoginUI()
             {
-                var options = new StuntmanOptions();
+                var options = StuntmanOptionsFactory.GetDefaultTestOptions();
 
                 using (var server = TestServer.Create(app =>
                 {
@@ -49,7 +49,7 @@ namespace RimDev.Stuntman.Core.Tests
             [Fact]
             public async Task SignInUri_OverrideSpecified_ThrowsIfNoMatchingUser()
             {
-                var options = new StuntmanOptions();
+                var options = StuntmanOptionsFactory.GetDefaultTestOptions();
 
                 using (var server = TestServer.Create(app =>
                 {
@@ -70,7 +70,7 @@ namespace RimDev.Stuntman.Core.Tests
             [Fact]
             public async Task SignInUri_OverrideSpecified_SetsExpectedCookieName()
             {
-                var options = new StuntmanOptions()
+                var options = StuntmanOptionsFactory.GetDefaultTestOptions()
                     .AddUser(new StuntmanUser("user-1", "User 1"));
 
                 using (var server = TestServer.Create(app =>
@@ -97,7 +97,7 @@ namespace RimDev.Stuntman.Core.Tests
             InlineData("Bearer 123 456 789")]
             public async Task AuthorizationBearerToken_400IfNoCorrectFormat(string bearerToken)
             {
-                var options = new StuntmanOptions();
+                var options = StuntmanOptionsFactory.GetDefaultTestOptions();
 
                 using (var server = TestServer.Create(app =>
                 {
@@ -125,7 +125,7 @@ namespace RimDev.Stuntman.Core.Tests
             [Fact]
             public async Task AuthorizationBearerToken_ThrowsIfNoMatchingUser()
             {
-                var options = new StuntmanOptions();
+                var options = StuntmanOptionsFactory.GetDefaultTestOptions();
 
                 using (var server = TestServer.Create(app =>
                 {
@@ -153,7 +153,7 @@ namespace RimDev.Stuntman.Core.Tests
             [Fact]
             public async Task AuthorizationBearerToken_AddsTokenClaim()
             {
-                var options = new StuntmanOptions()
+                var options = StuntmanOptionsFactory.GetDefaultTestOptions()
                     .AddUser(
                     new StuntmanUser("user-1", "User 1")
                     .SetAccessToken("123"));
@@ -192,7 +192,7 @@ namespace RimDev.Stuntman.Core.Tests
             [Fact]
             public async Task SignOutUri_Returns302Redirect()
             {
-                var options = new StuntmanOptions();
+                var options = StuntmanOptionsFactory.GetDefaultTestOptions();
 
                 using (var server = TestServer.Create(app =>
                 {
@@ -208,7 +208,7 @@ namespace RimDev.Stuntman.Core.Tests
             [Fact]
             public async Task SignOutUri_RemovesExpectedCookieName()
             {
-                var options = new StuntmanOptions();
+                var options = StuntmanOptionsFactory.GetDefaultTestOptions();
 
                 using (var server = TestServer.Create(app =>
                 {
@@ -229,7 +229,7 @@ namespace RimDev.Stuntman.Core.Tests
             [Fact]
             public async Task SignOutUri_ReturnsExpectedLocationHeader()
             {
-                var options = new StuntmanOptions();
+                var options = StuntmanOptionsFactory.GetDefaultTestOptions();
 
                 using (var server = TestServer.Create(app =>
                 {

--- a/tests/Core.Tests/StuntmanOptionsFactory.cs
+++ b/tests/Core.Tests/StuntmanOptionsFactory.cs
@@ -1,0 +1,13 @@
+﻿namespace RimDev.Stuntman.Core.Tests
+{
+    public class StuntmanOptionsFactory
+    {
+        public static StuntmanOptions GetDefaultTestOptions()
+        {
+            var options = new StuntmanOptions()
+                .AllowNonDebugUsage();
+
+            return options;
+        }
+    }
+}

--- a/tests/Core.Tests/StuntmanOptionsTests.cs
+++ b/tests/Core.Tests/StuntmanOptionsTests.cs
@@ -6,6 +6,26 @@ namespace RimDev.Stuntman.Core.Tests
 {
     public class StuntmanOptionsTests
     {
+        public class NonDebugUsageAllowedProperty
+        {
+            [Fact]
+            public void FalseByDefault()
+            {
+                var sut = new StuntmanOptions();
+
+                Assert.False(sut.NonDebugUsageAllowed);
+            }
+
+            [Fact]
+            public void TrueWhenAllowNonDebugUsageIsInvoked()
+            {
+                var sut = new StuntmanOptions()
+                    .AllowNonDebugUsage();
+
+                Assert.True(sut.NonDebugUsageAllowed);
+            }
+        }
+
         public class SignInUriProperty
         {
             [Fact]
@@ -112,6 +132,57 @@ namespace RimDev.Stuntman.Core.Tests
                     });
 
                 Assert.Equal("user must have unique Id.", exception.Message);
+            }
+        }
+
+        public class AllowNonDebugUsageMethod
+        {
+            [Fact]
+            public void UpdatesNonDebugUsageAllowedProperty()
+            {
+                var sut = new StuntmanOptions();
+
+                sut.AllowNonDebugUsage();
+
+                Assert.True(sut.NonDebugUsageAllowed);
+            }
+        }
+
+        public class VerifyUsageIsPermittedMethod
+        {
+            [Fact]
+            public void ThrowsWhenDebugIsFalse()
+            {
+                var sut = new StuntmanOptions(isDebug: () => false);
+
+                Assert.Throws<InvalidOperationException>(
+                    () => sut.VerifyUsageIsPermitted());
+            }
+
+            [Fact]
+            public void DoesNotThrowWhenDebugIsFalseAndAllowNonDebugUsageIsInvoked()
+            {
+                var sut = new StuntmanOptions(isDebug: () => false)
+                    .AllowNonDebugUsage();
+
+                sut.VerifyUsageIsPermitted();
+            }
+
+            [Fact]
+            public void DoesNotThrowWhenAndDebugIsTrue()
+            {
+                var sut = new StuntmanOptions(isDebug: () => true);
+
+                sut.VerifyUsageIsPermitted();
+            }
+
+            [Fact]
+            public void DoesNotThrowWhenDebugIsTrueAndAllowNonDebugUsageIsInvoked()
+            {
+                var sut = new StuntmanOptions(isDebug: () => true)
+                    .AllowNonDebugUsage();
+
+                sut.VerifyUsageIsPermitted();
             }
         }
     }

--- a/tests/Core.Tests/UserPickerTests.cs
+++ b/tests/Core.Tests/UserPickerTests.cs
@@ -13,7 +13,7 @@ namespace RimDev.Stuntman.Core.Tests
             [Fact]
             public void ThrowsForNullCurrentPrincipal()
             {
-                var options = new StuntmanOptions();
+                var options = StuntmanOptionsFactory.GetDefaultTestOptions();
 
                 Assert.Throws<ArgumentNullException>(
                     () => new UserPicker(options)
@@ -23,7 +23,7 @@ namespace RimDev.Stuntman.Core.Tests
             [Fact]
             public void ThrowsForNullReturnUrl()
             {
-                var options = new StuntmanOptions();
+                var options = StuntmanOptionsFactory.GetDefaultTestOptions();
 
                 Assert.Throws<ArgumentNullException>(
                     () => new UserPicker(options)
@@ -33,7 +33,7 @@ namespace RimDev.Stuntman.Core.Tests
             [Fact]
             public void ReturnsExpectedItemFormat()
             {
-                var options = new StuntmanOptions()
+                var options = StuntmanOptionsFactory.GetDefaultTestOptions()
                     .AddUser(new StuntmanUser("user-1", "User 1"));
 
                 var returnUrl = "https://return-url";
@@ -53,7 +53,7 @@ namespace RimDev.Stuntman.Core.Tests
             [Fact]
             public void ReturnsUsers()
             {
-                var options = new StuntmanOptions()
+                var options = StuntmanOptionsFactory.GetDefaultTestOptions()
                     .AddUser(new StuntmanUser("user-1", "User 1"))
                     .AddUser(new StuntmanUser("user-2", "User 2"));
 
@@ -69,7 +69,7 @@ namespace RimDev.Stuntman.Core.Tests
             [Fact]
             public void ReturnsLogout()
             {
-                var options = new StuntmanOptions();
+                var options = StuntmanOptionsFactory.GetDefaultTestOptions();
 
                 var html = new UserPicker(options).GetHtml(new TestPrincipal(), "https://return-url");
 
@@ -79,7 +79,7 @@ namespace RimDev.Stuntman.Core.Tests
             [Fact]
             public void ReturnsExpectedNumberOfTotalItems()
             {
-                var options = new StuntmanOptions()
+                var options = StuntmanOptionsFactory.GetDefaultTestOptions()
                     .AddUser(new StuntmanUser("user-1", "User 1"));
 
                 var html = new UserPicker(options).GetHtml(new TestPrincipal(), "https://return-url");


### PR DESCRIPTION
#23

Change stuntman to throw by default in 'normal' production environments (by default, the production environment is defined as a build missing the `DEBUG` constant).
## 

If we wanted to take a different approach, we could take the inclusion/non-inclusion of stuntman functionality based on environment on as a first class citizen in stuntman, rather than simply throwing for this behavior when not overridden.
