### PR TITLE
[WIP] Add helmet colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ public class Startup
               .AddClaim("given_name", "John")
               .AddClaim("family_name", "Doe"));
 
-        // Optionally assign a user an access token.
+        // Optionally assign a user an access token and icon color.
         options
           .AddUser(new StuntmanUser("user-2", "User 2")
               .SetAccessToken("123")
+              .SetIconColor(StuntmanColor.DarkBlue) // Includes overload for specific hex codes, too!
               .AddClaim("given_name", "Mary")
               .AddClaim("family_name", "Smith"));
 

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -67,6 +67,7 @@
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
     <Compile Include="Resources.cs" />
+    <Compile Include="StuntmanColor.cs" />
     <Compile Include="StuntmanOptions.cs" />
     <Compile Include="StuntmanUser.cs" />
     <Compile Include="UserPicker.cs" />

--- a/src/Core/StuntmanColor.cs
+++ b/src/Core/StuntmanColor.cs
@@ -1,0 +1,31 @@
+﻿using System.ComponentModel;
+
+namespace RimDev.Stuntman.Core
+{
+    public enum StuntmanColor
+    {
+        [Description("#002a4a")]
+        DarkBlue,
+
+        [Description("#17607d")]
+        MediumBlue,
+
+        [Description("#3dbad1")]
+        LightBlue,
+
+        [Description("#fff1ce")]
+        Cream,
+
+        [Description("#ff9311")]
+        Orange,
+
+        [Description("#d64700")]
+        Rust,
+
+        [Description("#4f731a")]
+        Forest,
+
+        [Description("#019c77")]
+        Sage,
+    }
+}

--- a/src/Core/StuntmanUser.cs
+++ b/src/Core/StuntmanUser.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Security.Claims;
 
 namespace RimDev.Stuntman.Core
@@ -23,7 +24,7 @@ namespace RimDev.Stuntman.Core
         /// Creates a new user with an auto-generated Id.
         /// </summary>
         public StuntmanUser(string name)
-            :this(
+            : this(
             id: Guid.NewGuid().ToString("D"),
             name: name)
         {
@@ -34,6 +35,8 @@ namespace RimDev.Stuntman.Core
         public string Id { get; private set; }
 
         public string Name { get; private set; }
+
+        public string IconColor { get; private set; }
 
         public ICollection<Claim> Claims { get; private set; }
 
@@ -56,6 +59,30 @@ namespace RimDev.Stuntman.Core
             if (string.IsNullOrWhiteSpace(accessToken)) throw new ArgumentException("accessToken must not be empty or whitespace.");
 
             AccessToken = accessToken;
+
+            return this;
+        }
+
+        public StuntmanUser SetIconColor(string hexColor)
+        {
+            if (hexColor == null) throw new ArgumentNullException(nameof(hexColor));
+
+            if (!string.IsNullOrEmpty(hexColor) && !hexColor.StartsWith("#", StringComparison.OrdinalIgnoreCase))
+                throw new ArgumentException($"{hexColor} must start with #.");
+
+            IconColor = hexColor;
+
+            return this;
+        }
+
+        public StuntmanUser SetIconColor(StuntmanColor color)
+        {
+            // http://stackoverflow.com/a/1799401/941536
+            var memInfo = typeof(StuntmanColor).GetMember(color.ToString());
+            var attributes = memInfo[0].GetCustomAttributes(typeof(DescriptionAttribute), false);
+            var description = ((DescriptionAttribute)attributes[0]).Description;
+
+            SetIconColor(description);
 
             return this;
         }

--- a/tests/Core.Tests/StuntmanUsersTests.cs
+++ b/tests/Core.Tests/StuntmanUsersTests.cs
@@ -137,5 +137,51 @@ namespace RimDev.Stuntman.Core.Tests
                 Assert.Equal("accessToken must not be empty or whitespace.", exception.Message);
             }
         }
+
+        public class SetIconColorMethod_StringOverload
+        {
+            [Fact]
+            public void ThrowsForNullArgument()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new StuntmanUser("user-1", "User 1")
+                        .SetIconColor(null));
+            }
+
+            [Fact]
+            public void ThrowsWhenMissingNumberSign()
+            {
+                const string hexColor = "ccc";
+
+                var exception = Assert.Throws<ArgumentException>(
+                    () => new StuntmanUser("user-1", "User 1")
+                        .SetIconColor(hexColor));
+
+                Assert.Equal($"{hexColor} must start with #.", exception.Message);
+            }
+
+            [Fact]
+            public void SetsExpectedColor()
+            {
+                const string hexColor = "#ccc";
+
+                var user = new StuntmanUser("user-1", "User 1")
+                    .SetIconColor(hexColor);
+
+                Assert.Equal(hexColor, user.IconColor);
+            }
+        }
+
+        public class SetIconColorMethod_StuntmanColorOverload
+        {
+            [Fact]
+            public void SetsExpectedColor()
+            {
+                var user = new StuntmanUser("user-1", "User 1")
+                    .SetIconColor(StuntmanColor.DarkBlue);
+
+                Assert.Equal("#002a4a", user.IconColor);
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds the ability icon color for a user using one of the two `SetIconColor` overloads.

Does not yet include the colored helmets showing up on the UI, though.
