### PR TITLE
Add client/server functionality

### DIFF
--- a/Stuntman.sln
+++ b/Stuntman.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UsageSampleMvc", "samples\U
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UsageSample.BearerTokenTester", "samples\UsageSample.BearerTokenTester\UsageSample.BearerTokenTester.csproj", "{CF8863AC-C37A-4E89-86FE-9B365818D9F2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UsageSample.ServerTester", "samples\UsageSample.ServerTester\UsageSample.ServerTester.csproj", "{EE3E17BB-74F9-4314-A529-5DE79B9E7D34}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -43,6 +45,10 @@ Global
 		{CF8863AC-C37A-4E89-86FE-9B365818D9F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CF8863AC-C37A-4E89-86FE-9B365818D9F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CF8863AC-C37A-4E89-86FE-9B365818D9F2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EE3E17BB-74F9-4314-A529-5DE79B9E7D34}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EE3E17BB-74F9-4314-A529-5DE79B9E7D34}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EE3E17BB-74F9-4314-A529-5DE79B9E7D34}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EE3E17BB-74F9-4314-A529-5DE79B9E7D34}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -52,5 +58,6 @@ Global
 		{6CCC791E-78A8-415F-8D9C-4A9F11449A19} = {418B6F96-6578-4B18-823C-0FC7A712F0BE}
 		{0CB0CB75-7BF7-44BD-A003-E4176AFD4EBC} = {418B6F96-6578-4B18-823C-0FC7A712F0BE}
 		{CF8863AC-C37A-4E89-86FE-9B365818D9F2} = {418B6F96-6578-4B18-823C-0FC7A712F0BE}
+		{EE3E17BB-74F9-4314-A529-5DE79B9E7D34} = {418B6F96-6578-4B18-823C-0FC7A712F0BE}
 	EndGlobalSection
 EndGlobal

--- a/samples/UsageSample.ServerTester/App.config
+++ b/samples/UsageSample.ServerTester/App.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="UsageSample:BaseUrl" value="http://localhost:54917/" />
+  </appSettings>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+  </startup>
+</configuration>

--- a/samples/UsageSample.ServerTester/Program.cs
+++ b/samples/UsageSample.ServerTester/Program.cs
@@ -1,0 +1,36 @@
+﻿using RimDev.Stuntman.Core;
+using System;
+using System.Configuration;
+using System.Linq;
+
+namespace UsageSample.ServerTester
+{
+    internal class Program
+    {
+        private static StuntmanOptions StuntmanOptions = new StuntmanOptions();
+
+        private static void Main(string[] args)
+        {
+            var baseUrl = GetAppSetting("UsageSample:BaseUrl");
+
+            StuntmanOptions
+                .AddConfigurationFromServer(baseUrl);
+
+            Console.WriteLine("Users:");
+            Console.WriteLine(string.Join(
+                Environment.NewLine,
+                StuntmanOptions.Users.Select(x => $"- {x.Id}: {x.Name}")));
+
+            Console.ReadLine();
+        }
+
+        private static string GetAppSetting(string key)
+        {
+            var appSetting = ConfigurationManager.AppSettings[key];
+            if (appSetting == null)
+                throw new ApplicationException($"appSetting {key} must be set.");
+
+            return appSetting;
+        }
+    }
+}

--- a/samples/UsageSample.ServerTester/Properties/AssemblyInfo.cs
+++ b/samples/UsageSample.ServerTester/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Reflection;
+
+[assembly: AssemblyTitle("UsageSample.ServerTester")]

--- a/samples/UsageSample.ServerTester/UsageSample.ServerTester.csproj
+++ b/samples/UsageSample.ServerTester/UsageSample.ServerTester.csproj
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{EE3E17BB-74F9-4314-A529-5DE79B9E7D34}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>UsageSample.ServerTester</RootNamespace>
+    <AssemblyName>UsageSample.ServerTester</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\common\SolutionInfo.cs">
+      <Link>Properties\SolutionInfo.cs</Link>
+    </Compile>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Core\Core.csproj">
+      <Project>{a3951ed6-0ad3-424c-b5bc-8008c80eea02}</Project>
+      <Name>Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/samples/UsageSample/Startup.cs
+++ b/samples/UsageSample/Startup.cs
@@ -14,6 +14,7 @@ namespace RimDev.Stuntman.UsageSample
         public void Configuration(IAppBuilder app)
         {
             StuntmanOptions
+                .EnableServer()
                 .AddUser(new StuntmanUser("user-1", "User 1")
                     .SetAccessToken("user-1-token")
                     .AddClaim("given_name", "John")

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -11,6 +11,7 @@
             public const string SignOutEndpoint = "sign-out";
             public const string OverrideQueryStringKey = "OverrideUserId";
             public const string ReturnUrlQueryStringKey = "ReturnUrl";
+            public const string ServerEndpoint = "server";
         }
     }
 }

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -72,6 +72,7 @@
     <Compile Include="StuntmanClaimConverter.cs" />
     <Compile Include="StuntmanOptions.cs" />
     <Compile Include="StuntmanOptionsRetriever.cs" />
+    <Compile Include="StuntmanServerResponse.cs" />
     <Compile Include="StuntmanUser.cs" />
     <Compile Include="UserPicker.cs" />
   </ItemGroup>

--- a/src/Core/IAppBuilderExtensions.cs
+++ b/src/Core/IAppBuilderExtensions.cs
@@ -2,6 +2,7 @@
 using Microsoft.Owin.Security;
 using Microsoft.Owin.Security.Cookies;
 using Microsoft.Owin.Security.OAuth;
+using Newtonsoft.Json;
 using Owin;
 using System;
 using System.Collections.Generic;
@@ -89,6 +90,21 @@ namespace RimDev.Stuntman.Core
 
                 RedirectToReturnUrl(signout);
             });
+
+            if (options.ServerEnabled)
+            {
+                app.Map(options.ServerUri, server =>
+                {
+                    server.Use(async (context, next) =>
+                    {
+                        var response = new StuntmanServerResponse { Users = options.Users };
+                        var json = JsonConvert.SerializeObject(response);
+
+                        context.Response.ContentType = "application/json";
+                        await context.Response.WriteAsync(json);
+                    });
+                });
+            }
         }
 
         private static string GetUsersLoginUI(

--- a/src/Core/StuntmanServerResponse.cs
+++ b/src/Core/StuntmanServerResponse.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace RimDev.Stuntman.Core
+{
+    public class StuntmanServerResponse
+    {
+        public IEnumerable<StuntmanUser> Users { get; set; } = new List<StuntmanUser>();
+    }
+}


### PR DESCRIPTION
#105

Add functionality for Stuntman enabled applications to read configuration information exposed by other Stuntman enabled applications when `EnableServer()` is used.

Currently, only the server's configured users are shared. This could be expanded in the future by adding additional information to the `StuntmanServerResponse` and working with it as necessary.
