### PR TITLE
Add ability to disable parts of Stuntman

### DIFF
--- a/build/Build.Version.targets
+++ b/build/Build.Version.targets
@@ -2,8 +2,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MajorVersion>1</MajorVersion>
-    <MinorVersion>1</MinorVersion>
-    <PatchVersion>1</PatchVersion>
+    <MinorVersion>2</MinorVersion>
+    <PatchVersion>0</PatchVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/RimDev.Stuntman.AspNetCore/common/StuntmanOptions.cs
+++ b/src/RimDev.Stuntman.AspNetCore/common/StuntmanOptions.cs
@@ -25,6 +25,19 @@ namespace RimDev.Stuntman.Core
         }
 
         /// <summary>
+        /// Determines whether bearer token authentication is enabled
+        /// when calling `UseStuntman`.
+        /// </summary>
+        public bool AllowBearerTokenAuthentication { get; set; } = true;
+
+        /// <summary>
+        /// Determines whether the UI-driven authentication is enabled
+        /// when calling `UseStuntman`. This also determines whether cookie authentication is enabled
+        /// since the two are related.
+        /// </summary>
+        public bool AllowCookieAuthentication { get; set; } = true;
+
+        /// <summary>
         /// The current alignment of the on-screen user picker.
         /// </summary>
         public StuntmanAlignment UserPickerAlignment { get; private set; }


### PR DESCRIPTION
Current behavior registers both cookie and bearer token providers and there is no way to only use one or the other.
New behavior allows selective disabling.

Note: this could allow someone to effectively use Stuntman AND disable both things that make Stuntman useful.

Implements https://github.com/ritterim/stuntman/issues/133