### PR TITLE
Allow bearer token passthrough

### DIFF
--- a/build/Build.Version.targets
+++ b/build/Build.Version.targets
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MajorVersion>1</MajorVersion>
-    <MinorVersion>2</MinorVersion>
+    <MinorVersion>3</MinorVersion>
     <PatchVersion>0</PatchVersion>
   </PropertyGroup>
 

--- a/src/Core/IAppBuilderExtensions.cs
+++ b/src/Core/IAppBuilderExtensions.cs
@@ -238,11 +238,14 @@ namespace RimDev.Stuntman.Core
 
                         if (user == null)
                         {
-                            context.Response.StatusCode = 403;
-                            context.Response.ReasonPhrase =
-                                $"options provided does not include the requested '{accessToken}' user.";
+                            if (!options.AllowBearerTokenPassthrough)
+                            {
+                                context.Response.StatusCode = 403;
+                                context.Response.ReasonPhrase =
+                                    $"options provided does not include the requested '{accessToken}' user.";
 
-                            context.Rejected();
+                                context.Rejected();
+                            }
 
                             return Task.FromResult(false);
                         }

--- a/src/RimDev.Stuntman.AspNetCore/common/StuntmanOptions.cs
+++ b/src/RimDev.Stuntman.AspNetCore/common/StuntmanOptions.cs
@@ -31,6 +31,13 @@ namespace RimDev.Stuntman.Core
         public bool AllowBearerTokenAuthentication { get; set; } = true;
 
         /// <summary>
+        /// Allows multiple bearer token providers to be used.
+        /// When `true`, a bearer token not matching a Stuntman user
+        /// does not result in an immediate `403`.
+        /// </summary>
+        public bool AllowBearerTokenPassthrough { get; set; }
+
+        /// <summary>
         /// Determines whether the UI-driven authentication is enabled
         /// when calling `UseStuntman`. This also determines whether cookie authentication is enabled
         /// since the two are related.


### PR DESCRIPTION
This enables a scenario where multiple bearer token middlewares are setup.
Previous behavior would stop at Stuntman with 403 if token did not match existing Stuntman user.

Implements https://github.com/ritterim/stuntman/issues/134