### PR TITLE
Fix server-endpoint related to getting users

### DIFF
--- a/build/Build.Version.targets
+++ b/build/Build.Version.targets
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MajorVersion>1</MajorVersion>
-    <MinorVersion>4</MinorVersion>
+    <MinorVersion>5</MinorVersion>
     <PatchVersion>0</PatchVersion>
   </PropertyGroup>
 

--- a/src/RimDev.Stuntman.AspNetCore/common/StuntmanOptions.cs
+++ b/src/RimDev.Stuntman.AspNetCore/common/StuntmanOptions.cs
@@ -119,11 +119,11 @@ namespace RimDev.Stuntman.Core
                 ? _stuntmanOptionsRetriever.GetStringFromLocalFile(uri)
                 : _stuntmanOptionsRetriever.GetStringUsingWebClient(uri);
 
-            var users = JsonConvert.DeserializeObject<IEnumerable<StuntmanUser>>(
+            var users = JsonConvert.DeserializeObject<StuntmanServerResponse>(
                 json,
                 new StuntmanClaimConverter());
 
-            foreach (var user in users)
+            foreach (var user in users.Users)
             {
                 AddUser(user, pathOrUrl);
             }

--- a/tests/Core.AspNetCore.Tests/common/StuntmanOptionsTests.cs
+++ b/tests/Core.AspNetCore.Tests/common/StuntmanOptionsTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace RimDev.Stuntman.Core.Tests
 {
-    public class StuntmanOptionsTests
+    public partial class StuntmanOptionsTests
     {
         public class SignInUriProperty
         {
@@ -140,7 +140,7 @@ namespace RimDev.Stuntman.Core.Tests
             }
         }
 
-        public class AddUsersFromJsonMethod
+        public partial class AddUsersFromJsonMethod
         {
             [Fact]
             public void ThrowsForNullPathOrUrl()
@@ -169,86 +169,6 @@ namespace RimDev.Stuntman.Core.Tests
                 Assert.Throws<JsonReaderException>(
                     () => new StuntmanOptions(stuntmanOptionsRetriever: new TestStuntmanOptionsRetriever(json))
                         .AddUsersFromJson("C:\\test.json"));
-            }
-
-            [Fact]
-            public void AddsUsersFromFileSystem()
-            {
-                const string Id1 = "user-1";
-                const string Name1 = "Test Name 1";
-
-                const string Id2 = "user-2";
-                const string Name2 = "Test Name 2";
-
-                var json = $@"[{{""Id"":""{Id1}"",""Name"":""{Name1}""}},{{""Id"":""{Id2}"",""Name"":""{Name2}""}}]";
-
-                var options = new StuntmanOptions(
-                    stuntmanOptionsRetriever:
-                        new TestStuntmanOptionsRetriever(localFileStringToReturn: json))
-                    .AddUsersFromJson("C:\\test.json");
-
-                Assert.Equal(2, options.Users.Count);
-
-                Assert.NotNull(options.Users.SingleOrDefault(x => x.Id == Id1));
-                Assert.NotNull(options.Users.SingleOrDefault(x => x.Name == Name1));
-
-                Assert.NotNull(options.Users.SingleOrDefault(x => x.Id == Id2));
-                Assert.NotNull(options.Users.SingleOrDefault(x => x.Name == Name2));
-            }
-
-            [Fact]
-            public void AddsUsersFromWebClientRequest()
-            {
-                const string Id1 = "user-1";
-                const string Name1 = "Test Name 1";
-
-                const string Id2 = "user-2";
-                const string Name2 = "Test Name 2";
-
-                var json = $@"[{{""Id"":""{Id1}"",""Name"":""{Name1}""}},{{""Id"":""{Id2}"",""Name"":""{Name2}""}}]";
-
-                var options = new StuntmanOptions(
-                    stuntmanOptionsRetriever:
-                        new TestStuntmanOptionsRetriever(webClientStringToReturn: json))
-                    .AddUsersFromJson("https://example.com");
-
-                Assert.Equal(2, options.Users.Count);
-
-                Assert.NotNull(options.Users.SingleOrDefault(x => x.Id == Id1));
-                Assert.NotNull(options.Users.SingleOrDefault(x => x.Name == Name1));
-
-                Assert.NotNull(options.Users.SingleOrDefault(x => x.Id == Id2));
-                Assert.NotNull(options.Users.SingleOrDefault(x => x.Name == Name2));
-            }
-
-            [Fact]
-            public void AddsUserClaims()
-            {
-                const string ClaimType = "TestClaim";
-                const string ClaimValue = "TestClaimValue";
-
-                var users = new List<StuntmanUser>
-                {
-                    new StuntmanUser("user-1", "Test Name 1")
-                        .AddClaim(ClaimType, ClaimValue),
-                    new StuntmanUser("user-2", "Test Name 2")
-                };
-
-                var json = JsonConvert.SerializeObject(users);
-
-                var options = new StuntmanOptions(
-                    stuntmanOptionsRetriever:
-                        new TestStuntmanOptionsRetriever(localFileStringToReturn: json))
-                    .AddUsersFromJson("C:\\test.json");
-
-                var user1 = options.Users.SingleOrDefault(x => x.Claims.Any());
-
-                Assert.NotNull(user1);
-
-                var testClaim = user1.Claims.Single();
-
-                Assert.Equal(ClaimType, testClaim.Type);
-                Assert.Equal(ClaimValue, testClaim.Value);
             }
         }
 

--- a/tests/Core.Tests/Core.Tests.csproj
+++ b/tests/Core.Tests/Core.Tests.csproj
@@ -104,6 +104,7 @@
     <Compile Include="..\..\common\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
+    <Compile Include="StuntmanOptionsTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Core\Core.csproj">

--- a/tests/Core.Tests/StuntmanOptionsTests.cs
+++ b/tests/Core.Tests/StuntmanOptionsTests.cs
@@ -1,0 +1,138 @@
+﻿using Microsoft.Owin.Testing;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RimDev.Stuntman.Core.Tests
+{
+    public partial class StuntmanOptionsTests
+    {
+        public partial class AddUsersFromJsonMethod
+        {
+            [Fact]
+            public async Task AddsUsersFromFileSystem()
+            {
+                const string Id1 = "user-1";
+                const string Name1 = "Test Name 1";
+
+                const string Id2 = "user-2";
+                const string Name2 = "Test Name 2";
+
+                var json = string.Empty;
+
+                var stuntmanOptions = new StuntmanOptions()
+                    .AddUser(new StuntmanUser(Id1, Name1))
+                    .AddUser(new StuntmanUser(Id2, Name2));
+
+                using (var server = TestServer.Create(app =>
+                {
+                    stuntmanOptions.EnableServer();
+
+                    app.UseStuntman(stuntmanOptions);
+                }))
+                {
+                    var response = await server.HttpClient.GetAsync(stuntmanOptions.ServerUri);
+
+                    json = await response.Content.ReadAsStringAsync();
+                }
+
+                var options = new StuntmanOptions(
+                    stuntmanOptionsRetriever:
+                        new TestStuntmanOptionsRetriever(localFileStringToReturn: json))
+                    .AddUsersFromJson("C:\\test.json");
+
+                Assert.Equal(2, options.Users.Count);
+
+                Assert.NotNull(options.Users.SingleOrDefault(x => x.Id == Id1));
+                Assert.NotNull(options.Users.SingleOrDefault(x => x.Name == Name1));
+
+                Assert.NotNull(options.Users.SingleOrDefault(x => x.Id == Id2));
+                Assert.NotNull(options.Users.SingleOrDefault(x => x.Name == Name2));
+            }
+
+            [Fact]
+            public async Task AddsUsersFromWebClientRequest()
+            {
+                const string Id1 = "user-1";
+                const string Name1 = "Test Name 1";
+
+                const string Id2 = "user-2";
+                const string Name2 = "Test Name 2";
+
+                var json = string.Empty;
+
+                var stuntmanOptions = new StuntmanOptions()
+                    .AddUser(new StuntmanUser(Id1, Name1))
+                    .AddUser(new StuntmanUser(Id2, Name2));
+
+                using (var server = TestServer.Create(app =>
+                {
+                    stuntmanOptions.EnableServer();
+
+                    app.UseStuntman(stuntmanOptions);
+                }))
+                {
+                    var response = await server.HttpClient.GetAsync(stuntmanOptions.ServerUri);
+
+                    json = await response.Content.ReadAsStringAsync();
+                }
+
+                var options = new StuntmanOptions(
+                    stuntmanOptionsRetriever:
+                        new TestStuntmanOptionsRetriever(webClientStringToReturn: json))
+                    .AddUsersFromJson("https://example.com");
+
+                Assert.Equal(2, options.Users.Count);
+
+                Assert.NotNull(options.Users.SingleOrDefault(x => x.Id == Id1));
+                Assert.NotNull(options.Users.SingleOrDefault(x => x.Name == Name1));
+
+                Assert.NotNull(options.Users.SingleOrDefault(x => x.Id == Id2));
+                Assert.NotNull(options.Users.SingleOrDefault(x => x.Name == Name2));
+            }
+
+            [Fact]
+            public async Task AddsUserClaims()
+            {
+                const string ClaimType = "TestClaim";
+                const string ClaimValue = "TestClaimValue";
+
+                var json = string.Empty;
+
+                var stuntmanOptions = new StuntmanOptions()
+                    .AddUser(new StuntmanUser("user-1", "Test Name 1")
+                        .AddClaim(ClaimType, ClaimValue))
+                    .AddUser(new StuntmanUser("user-2", "Test Name 2"));
+
+                using (var server = TestServer.Create(app =>
+                {
+                    stuntmanOptions.EnableServer();
+
+                    app.UseStuntman(stuntmanOptions);
+                }))
+                {
+                    var response = await server.HttpClient.GetAsync(stuntmanOptions.ServerUri);
+
+                    json = await response.Content.ReadAsStringAsync();
+                }
+
+                var options = new StuntmanOptions(
+                    stuntmanOptionsRetriever:
+                        new TestStuntmanOptionsRetriever(localFileStringToReturn: json))
+                    .AddUsersFromJson("C:\\test.json");
+
+                var user1 = options.Users.SingleOrDefault(x => x.Claims.Any());
+
+                Assert.NotNull(user1);
+
+                var testClaim = user1.Claims.Single();
+
+                Assert.Equal(ClaimType, testClaim.Type);
+                Assert.Equal(ClaimValue, testClaim.Value);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Previous behavior had tests, but they did not represent the current state of how the tested-endpoint behaves.
New behavior provides tests which call the actual endpoint to get the data to be used in the tests.