### PR TITLE
Add optional configureUsers parameter

### DIFF
--- a/build/Build.Version.targets
+++ b/build/Build.Version.targets
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MajorVersion>1</MajorVersion>
-    <MinorVersion>5</MinorVersion>
+    <MinorVersion>6</MinorVersion>
     <PatchVersion>0</PatchVersion>
   </PropertyGroup>
 

--- a/src/RimDev.Stuntman.AspNetCore/common/StuntmanOptions.cs
+++ b/src/RimDev.Stuntman.AspNetCore/common/StuntmanOptions.cs
@@ -109,7 +109,9 @@ namespace RimDev.Stuntman.Core
         /// Add users from JSON at the file system path or URL specified.
         /// The expected JSON format is [{"Id":"user-1","Name":"User 1"}]
         /// </summary>
-        public StuntmanOptions AddUsersFromJson(string pathOrUrl)
+        /// <param name="pathOrUrl">The path or url to the JSON file.</param>
+        /// <param name="configureUsers">Optionally configure all users prior to being added.</param>
+        public StuntmanOptions AddUsersFromJson(string pathOrUrl, Action<StuntmanUser> configureUsers = null)
         {
             if (pathOrUrl == null) throw new ArgumentNullException(nameof(pathOrUrl));
 
@@ -125,6 +127,8 @@ namespace RimDev.Stuntman.Core
 
             foreach (var user in users.Users)
             {
+                configureUsers?.Invoke(user);
+
                 AddUser(user, pathOrUrl);
             }
 


### PR DESCRIPTION
Add optional `configureUsers` parameter to `StuntmanOptions`'s `AddUsersFromJson` method.