### PR TITLE
Added AddUsers to StuntmanOptions

### DIFF
--- a/build/Build.Version.targets
+++ b/build/Build.Version.targets
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MajorVersion>1</MajorVersion>
-    <MinorVersion>6</MinorVersion>
+    <MinorVersion>7</MinorVersion>
     <PatchVersion>0</PatchVersion>
   </PropertyGroup>
 

--- a/src/RimDev.Stuntman.AspNetCore/common/StuntmanOptions.cs
+++ b/src/RimDev.Stuntman.AspNetCore/common/StuntmanOptions.cs
@@ -83,6 +83,16 @@ namespace RimDev.Stuntman.Core
             return AddUser(user, Constants.StuntmanOptions.LocalSource);
         }
 
+        public StuntmanOptions AddUsers(IEnumerable<StuntmanUser> users) 
+        {
+            if (users == null) throw new ArgumentNullException(nameof(users));
+
+            foreach(var user in users)
+                AddUser(user);
+
+            return this;
+        }
+
         /// <remarks>
         /// This method is private to avoid exposing it as part of the public API.
         /// </remarks>

--- a/src/RimDev.Stuntman.AspNetCore/project.json
+++ b/src/RimDev.Stuntman.AspNetCore/project.json
@@ -1,5 +1,5 @@
 ﻿{
-    "version": "1.6.0-*",
+    "version": "1.7.0-*",
     "authors": [ "Ritter Insurance Marketing" ],
     "copyright": "Copyright 2017 Ritter Insurance Marketing",
 

--- a/tests/Core.Tests/StuntmanOptionsTests.cs
+++ b/tests/Core.Tests/StuntmanOptionsTests.cs
@@ -168,5 +168,18 @@ namespace RimDev.Stuntman.Core.Tests
                     x => x.Claims.Count(y => y.Type == TestClaim && y.Value == TestClaimValue) == 1));
             }
         }
+
+        [Fact]
+        public void AddUsersFromCollection() 
+        {
+            var users = Enumerable.Range(1, 10)
+                       .Select(i => new StuntmanUser(i.ToString(), $"user-{i}"))
+                       .ToList();
+
+            var options = new StuntmanOptions()
+                          .AddUsers(users);
+
+            Assert.Equal(10, options.Users.Count);
+        }
     }
 }


### PR DESCRIPTION
Added `AddUsers` for scenarios where an array of `StuntmanUsers` are built programmatically and then added to `StuntmanOptions`.

This should help developers not do something gross like

```csharp
users.ForEach(stuntmanUser => options.AddUser(stuntmanUser));
```

Instead they can just do the following.

```
options.AddUsers(users)
```

